### PR TITLE
add missing indices in interp_fun call

### DIFF
--- a/source/fortran/2d/quatenergy.m4
+++ b/source/fortran/2d/quatenergy.m4
@@ -446,7 +446,7 @@ c
 
             if ( three_phase /= 0 ) then
                f_b = fb(i,j)
-               h_eta = interp_func( eta, eta_interp_type )
+               h_eta = interp_func( eta(i,j), eta_interp_type )
             else
                f_b = 0.0d0
                h_eta = 0.0d0


### PR DESCRIPTION
When I tried to compile this in a Fedora 32 Docker container, I got an error message. I'm guessing it's from a newer version of g++. I presume that the "eta" just needs i,j indices, which is what I added here.