### PR TITLE
Clean up usage of base class FreeEnergy

### DIFF
--- a/source/BiasDoubleWellFreeEnergyStrategy.h
+++ b/source/BiasDoubleWellFreeEnergyStrategy.h
@@ -51,36 +51,6 @@ class BiasDoubleWellFreeEnergyStrategy : public FreeEnergyStrategy
 
    virtual ~BiasDoubleWellFreeEnergyStrategy(){};
 
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp)
-   {
-      (void)hierarchy;
-      (void)temperature_id;
-      (void)fl_id;
-      (void)gp;
-   };
-
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp)
-   {
-      (void)hierarchy;
-      (void)temperature_id;
-      (void)fs_id;
-      (void)gp;
-   };
-
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp)
-   {
-      (void)hierarchy;
-      (void)temperature_id;
-      (void)fs_id;
-      (void)gp;
-   };
-
    // mesh functions
    virtual void computeFreeEnergyLiquid(hier::Patch& patch,
                                         const int temperature_id,

--- a/source/CALPHADFreeEnergyStrategyBinary.cc
+++ b/source/CALPHADFreeEnergyStrategyBinary.cc
@@ -90,85 +90,39 @@ void CALPHADFreeEnergyStrategyBinary::setup(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(fl_id >= 0);
-
-   assert(d_conc_l_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fl_id, d_conc_l_id,
-                            PhaseIndex::phaseL, gp);
-}
-
-//=======================================================================
-
 void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfl_id)
+    hier::Patch& patch, const int temperature_id, const int dfl_id)
 {
    assert(temperature_id >= 0);
    assert(dfl_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfl_id, d_conc_l_id,
-                                 PhaseIndex::phaseL);
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinary::computeFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(temperature_id >= 0.);
-   assert(fs_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fs_id, d_conc_a_id,
-                            PhaseIndex::phaseA, gp);
+   computeDerivFreeEnergy(patch, temperature_id, dfl_id, d_conc_l_id,
+                          PhaseIndex::phaseL);
 }
 
 //=======================================================================
 
 void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfs_id)
+    hier::Patch& patch, const int temperature_id, const int dfs_id)
 {
    assert(temperature_id >= 0.);
    assert(dfs_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfs_id, d_conc_a_id,
-                                 PhaseIndex::phaseA);
+   computeDerivFreeEnergy(patch, temperature_id, dfs_id, d_conc_a_id,
+                          PhaseIndex::phaseA);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::computeFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(temperature_id >= 0.);
-   assert(fs_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fs_id, d_conc_b_id,
-                            PhaseIndex::phaseB, gp);
-}
-
-//=======================================================================
-
-#ifndef HAVE_THERMO4PFM
 void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfs_id)
+    hier::Patch& patch, const int temperature_id, const int dfs_id)
 {
    assert(temperature_id >= 0.);
    assert(dfs_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfs_id, d_conc_b_id,
-                                 PhaseIndex::phaseB);
+   computeDerivFreeEnergy(patch, temperature_id, dfs_id, d_conc_b_id,
+                          PhaseIndex::phaseB);
 }
-#endif
 
 //=======================================================================
 
@@ -181,8 +135,8 @@ void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyLiquid(
 
    assert(d_conc_l_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fl_id, d_conc_l_id,
-                            PhaseIndex::phaseL, gp);
+   computeFreeEnergy(patch, temperature_id, fl_id, d_conc_l_id,
+                     PhaseIndex::phaseL, gp);
 }
 
 //=======================================================================
@@ -194,8 +148,8 @@ void CALPHADFreeEnergyStrategyBinary::computeFreeEnergySolidA(
    assert(temperature_id >= 0.);
    assert(fs_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fs_id, d_conc_a_id,
-                            PhaseIndex::phaseA, gp);
+   computeFreeEnergy(patch, temperature_id, fs_id, d_conc_a_id,
+                     PhaseIndex::phaseA, gp);
 }
 
 //=======================================================================
@@ -207,13 +161,13 @@ void CALPHADFreeEnergyStrategyBinary::computeFreeEnergySolidB(
    assert(temperature_id >= 0.);
    assert(fs_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fs_id, d_conc_b_id,
-                            PhaseIndex::phaseB, gp);
+   computeFreeEnergy(patch, temperature_id, fs_id, d_conc_b_id,
+                     PhaseIndex::phaseB, gp);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyPrivate(
+void CALPHADFreeEnergyStrategyBinary::computeFreeEnergy(
     hier::Patch& patch, const int temperature_id, const int f_id,
     const int conc_i_id, const PhaseIndex pi, const bool gp)
 {
@@ -235,12 +189,12 @@ void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeFreeEnergyPrivatePatch(pbox, temperature, f, c_i, pi, gp);
+   computeFreeEnergy(pbox, temperature, f, c_i, pi, gp);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergyPrivate(
+void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergy(
     hier::Patch& patch, const int temperature_id, const int df_id,
     const int conc_i_id, const PhaseIndex pi)
 {
@@ -262,60 +216,12 @@ void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeDerivFreeEnergyPrivatePatch(pbox, temperature, df, c_i, pi);
+   computeDerivFreeEnergy(pbox, temperature, df, c_i, pi);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int f_id, const int conc_i_id,
-    const PhaseIndex pi, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(f_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeFreeEnergyPrivate(*patch, temperature_id, f_id, conc_i_id, pi,
-                                  gp);
-      }
-   }
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int df_id, const int conc_i_id,
-    const PhaseIndex pi)
-{
-   assert(temperature_id >= 0);
-   assert(df_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, df_id, conc_i_id,
-                                       pi);
-      }
-   }
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyPrivatePatch(
+void CALPHADFreeEnergyStrategyBinary::computeFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
@@ -395,7 +301,7 @@ void CALPHADFreeEnergyStrategyBinary::computeFreeEnergyPrivatePatch(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergyPrivatePatch(
+void CALPHADFreeEnergyStrategyBinary::computeDerivFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi)
@@ -570,12 +476,12 @@ void CALPHADFreeEnergyStrategyBinary::addDrivingForce(
 
    const hier::Box& pbox(patch.getBox());
 
-   addDrivingForceOnPatch(rhs, t, phase, eta, fl, fa, fb, c_l, c_a, c_b, pbox);
+   addDrivingForce(rhs, t, phase, eta, fl, fa, fb, c_l, c_a, c_b, pbox);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::addDrivingForceOnPatch(
+void CALPHADFreeEnergyStrategyBinary::addDrivingForce(
     std::shared_ptr<pdat::CellData<double> > cd_rhs,
     std::shared_ptr<pdat::CellData<double> > cd_temperature,
     std::shared_ptr<pdat::CellData<double> > cd_phi,
@@ -817,13 +723,12 @@ void CALPHADFreeEnergyStrategyBinary::addDrivingForceEta(
 
    const hier::Box& pbox = patch.getBox();
 
-   addDrivingForceEtaOnPatchPrivate(rhs, t, phase, eta, f_l, f_a, f_b, c_l, c_a,
-                                    c_b, pbox);
+   addDrivingForceEta(rhs, t, phase, eta, f_l, f_a, f_b, c_l, c_a, c_b, pbox);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinary::addDrivingForceEtaOnPatchPrivate(
+void CALPHADFreeEnergyStrategyBinary::addDrivingForceEta(
     std::shared_ptr<pdat::CellData<double> > cd_rhs,
     std::shared_ptr<pdat::CellData<double> > cd_temperature,
     std::shared_ptr<pdat::CellData<double> > cd_phi,

--- a/source/CALPHADFreeEnergyStrategyBinary.h
+++ b/source/CALPHADFreeEnergyStrategyBinary.h
@@ -15,7 +15,6 @@
 #include "ConcFreeEnergyStrategy.h"
 #include "CALPHADSpeciesPhaseGibbsEnergy.h"
 #include "CALPHADConcSolverBinary.h"
-#include "FreeEnergyStrategy.h"
 #include "CALPHADFreeEnergyFunctionsBinary.h"
 #include "FuncFort.h"
 
@@ -44,36 +43,21 @@ class CALPHADFreeEnergyStrategyBinary : public ConcFreeEnergyStrategy
    virtual void setup(std::shared_ptr<tbox::Database> calphad_db,
                       std::shared_ptr<tbox::Database> newton_db);
 
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp);
+   void computeDerivFreeEnergyLiquid(hier::Patch& patch,
+                                     const int temperature_id, const int fl_id);
 
-   void computeDerivFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id);
-
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
-
-   void computeDerivFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
+   void computeDerivFreeEnergySolidA(hier::Patch& patch,
+                                     const int temperature_id, const int fs_id);
 
    void computeFreeEnergyLiquid(hier::Patch& patch, const int temperature_id,
                                 const int fl_id, const bool gp);
 
    void computeFreeEnergySolidA(hier::Patch& patch, const int temperature_id,
                                 const int fs_id, const bool gp);
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
 
-#ifndef HAVE_THERMO4PFM
-   void computeDerivFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
-#endif
+   void computeDerivFreeEnergySolidB(hier::Patch& patch,
+                                     const int temperature_id, const int fs_id);
+
    void computeFreeEnergySolidB(hier::Patch& patch, const int temperature_id,
                                 const int fs_id, const bool gp);
 
@@ -222,48 +206,38 @@ class CALPHADFreeEnergyStrategyBinary : public ConcFreeEnergyStrategy
       return DERIV_INTERP_FUNC(phi, &interp);
    }
 
-   void addDrivingForceOnPatch(
-       std::shared_ptr<pdat::CellData<double> > cd_rhs,
-       std::shared_ptr<pdat::CellData<double> > cd_temperature,
-       std::shared_ptr<pdat::CellData<double> > cd_phi,
-       std::shared_ptr<pdat::CellData<double> > cd_eta,
-       std::shared_ptr<pdat::CellData<double> > cd_f_l,
-       std::shared_ptr<pdat::CellData<double> > cd_f_a,
-       std::shared_ptr<pdat::CellData<double> > cd_f_b,
-       std::shared_ptr<pdat::CellData<double> > cd_c_l,
-       std::shared_ptr<pdat::CellData<double> > cd_c_a,
-       std::shared_ptr<pdat::CellData<double> > cd_c_b, const hier::Box& pbox);
+   void addDrivingForce(std::shared_ptr<pdat::CellData<double> > cd_rhs,
+                        std::shared_ptr<pdat::CellData<double> > cd_temperature,
+                        std::shared_ptr<pdat::CellData<double> > cd_phi,
+                        std::shared_ptr<pdat::CellData<double> > cd_eta,
+                        std::shared_ptr<pdat::CellData<double> > cd_f_l,
+                        std::shared_ptr<pdat::CellData<double> > cd_f_a,
+                        std::shared_ptr<pdat::CellData<double> > cd_f_b,
+                        std::shared_ptr<pdat::CellData<double> > cd_c_l,
+                        std::shared_ptr<pdat::CellData<double> > cd_c_a,
+                        std::shared_ptr<pdat::CellData<double> > cd_c_b,
+                        const hier::Box& pbox);
 
-   void computeFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const int c_i_id,
-       const PhaseIndex pi, const bool gp);
+   void computeFreeEnergy(hier::Patch& patch, const int temperature_id,
+                          const int f_id, const int c_i_id, const PhaseIndex pi,
+                          const bool gp);
 
-   void computeDerivFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const int c_i_id,
-       const PhaseIndex pi);
+   void computeDerivFreeEnergy(hier::Patch& patch, const int temperature_id,
+                               const int f_id, const int c_i_id,
+                               const PhaseIndex pi);
 
-   void computeFreeEnergyPrivate(hier::Patch& patch, const int temperature_id,
-                                 const int f_id, const int c_i_id,
-                                 const PhaseIndex pi, const bool gp);
-
-   void computeDerivFreeEnergyPrivate(hier::Patch& patch,
-                                      const int temperature_id, const int f_id,
-                                      const int c_i_id, const PhaseIndex pi);
-
-   void computeFreeEnergyPrivatePatch(
+   void computeFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
        const bool gp);
 
-   void computeDerivFreeEnergyPrivatePatch(
+   void computeDerivFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi);
 
-   void addDrivingForceEtaOnPatchPrivate(
+   void addDrivingForceEta(
        std::shared_ptr<pdat::CellData<double> > cd_rhs,
        std::shared_ptr<pdat::CellData<double> > cd_temperature,
        std::shared_ptr<pdat::CellData<double> > cd_phi,

--- a/source/CALPHADFreeEnergyStrategyBinaryThreePhase.cc
+++ b/source/CALPHADFreeEnergyStrategyBinaryThreePhase.cc
@@ -81,81 +81,38 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::setup(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(fl_id >= 0);
-
-   assert(d_conc_l_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fl_id, d_conc_l_id,
-                            PhaseIndex::phaseL, gp);
-}
-
-//=======================================================================
-
 void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfl_id)
+    hier::Patch& patch, const int temperature_id, const int dfl_id)
 {
    assert(temperature_id >= 0);
    assert(dfl_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfl_id, d_conc_l_id,
-                                 PhaseIndex::phaseL);
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fa_id, const bool gp)
-{
-   assert(temperature_id >= 0.);
-   assert(fa_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fa_id, d_conc_a_id,
-                            PhaseIndex::phaseA, gp);
+   computeDerivFreeEnergy(patch, temperature_id, dfl_id, d_conc_l_id,
+                          PhaseIndex::phaseL);
 }
 
 //=======================================================================
 
 void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfa_id)
+    hier::Patch& patch, const int temperature_id, const int dfa_id)
 {
    assert(temperature_id >= 0.);
    assert(dfa_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfa_id, d_conc_a_id,
-                                 PhaseIndex::phaseA);
-}
-
-//=======================================================================
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fb_id, const bool gp)
-{
-   assert(temperature_id >= 0.);
-   assert(fb_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fb_id, d_conc_b_id,
-                            PhaseIndex::phaseB, gp);
+   computeDerivFreeEnergy(patch, temperature_id, dfa_id, d_conc_a_id,
+                          PhaseIndex::phaseA);
 }
 
 //=======================================================================
 
 void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfb_id)
+    hier::Patch& patch, const int temperature_id, const int dfb_id)
 {
    assert(temperature_id >= 0.);
    assert(dfb_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfb_id, d_conc_b_id,
-                                 PhaseIndex::phaseB);
+   computeDerivFreeEnergy(patch, temperature_id, dfb_id, d_conc_b_id,
+                          PhaseIndex::phaseB);
 }
 
 //=======================================================================
@@ -169,8 +126,8 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyLiquid(
 
    assert(d_conc_l_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fl_id, d_conc_l_id,
-                            PhaseIndex::phaseL, gp);
+   computeFreeEnergy(patch, temperature_id, fl_id, d_conc_l_id,
+                     PhaseIndex::phaseL, gp);
 }
 
 //=======================================================================
@@ -182,8 +139,8 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergySolidA(
    assert(temperature_id >= 0.);
    assert(fa_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fa_id, d_conc_a_id,
-                            PhaseIndex::phaseA, gp);
+   computeFreeEnergy(patch, temperature_id, fa_id, d_conc_a_id,
+                     PhaseIndex::phaseA, gp);
 }
 
 //=======================================================================
@@ -195,13 +152,13 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergySolidB(
    assert(temperature_id >= 0.);
    assert(fb_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fb_id, d_conc_b_id,
-                            PhaseIndex::phaseB, gp);
+   computeFreeEnergy(patch, temperature_id, fb_id, d_conc_b_id,
+                     PhaseIndex::phaseB, gp);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyPrivate(
+void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergy(
     hier::Patch& patch, const int temperature_id, const int f_id,
     const int conc_i_id, const PhaseIndex pi, const bool gp)
 {
@@ -223,12 +180,12 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeFreeEnergyPrivatePatch(pbox, temperature, f, c_i, pi, gp);
+   computeFreeEnergy(pbox, temperature, f, c_i, pi, gp);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergyPrivate(
+void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergy(
     hier::Patch& patch, const int temperature_id, const int df_id,
     const int conc_i_id, const PhaseIndex pi)
 {
@@ -250,60 +207,12 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeDerivFreeEnergyPrivatePatch(pbox, temperature, df, c_i, pi);
+   computeDerivFreeEnergy(pbox, temperature, df, c_i, pi);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int f_id, const int conc_i_id,
-    const PhaseIndex pi, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(f_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeFreeEnergyPrivate(*patch, temperature_id, f_id, conc_i_id, pi,
-                                  gp);
-      }
-   }
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int df_id, const int conc_i_id,
-    const PhaseIndex pi)
-{
-   assert(temperature_id >= 0);
-   assert(df_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, df_id, conc_i_id,
-                                       pi);
-      }
-   }
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyPrivatePatch(
+void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
@@ -383,11 +292,10 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::computeFreeEnergyPrivatePatch(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyBinaryThreePhase::
-    computeDerivFreeEnergyPrivatePatch(
-        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
-        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
-        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi)
+void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDerivFreeEnergy(
+    const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
+    std::shared_ptr<pdat::CellData<double> > cd_free_energy,
+    std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi)
 {
    double* ptr_temp = cd_temp->getPointer();
    double* ptr_f = cd_free_energy->getPointer();
@@ -460,18 +368,6 @@ void CALPHADFreeEnergyStrategyBinaryThreePhase::
       }
    }
 }
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyBinaryThreePhase::computeDrivingForce(
-    const double time, hier::Patch& patch, const int temperature_id,
-    const int phase_id, const int eta_id, const int conc_id, const int f_l_id,
-    const int f_a_id, const int f_b_id, const int rhs_id)
-{
-   FreeEnergyStrategy::computeDrivingForce(time, patch, temperature_id,
-                                           phase_id, eta_id, conc_id, f_l_id,
-                                           f_a_id, f_b_id, rhs_id);
-};
 
 //=======================================================================
 

--- a/source/CALPHADFreeEnergyStrategyBinaryThreePhase.h
+++ b/source/CALPHADFreeEnergyStrategyBinaryThreePhase.h
@@ -45,48 +45,31 @@ class CALPHADFreeEnergyStrategyBinaryThreePhase : public ConcFreeEnergyStrategy
    virtual void setup(boost::property_tree::ptree calphad_db,
                       std::shared_ptr<tbox::Database> newton_db);
 
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp);
-
-   void computeDerivFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id);
-
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
-
-   void computeDerivFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
-
+   // implement pure virtual functions of FreeEnergyStrategy
    void computeFreeEnergyLiquid(hier::Patch& patch, const int temperature_id,
                                 const int fl_id, const bool gp);
 
    void computeFreeEnergySolidA(hier::Patch& patch, const int temperature_id,
                                 const int fs_id, const bool gp);
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
 
    void computeFreeEnergySolidB(hier::Patch& patch, const int temperature_id,
                                 const int fs_id, const bool gp);
-   void computeDerivFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
+
+   // implement pure virtual functions of ConcFreeEnergyStrategy
+   void computeDerivFreeEnergyLiquid(hier::Patch& patch,
+                                     const int temperature_id, const int fl_id);
+
+   void computeDerivFreeEnergySolidA(hier::Patch& patch,
+                                     const int temperature_id, const int fs_id);
+
+   void computeDerivFreeEnergySolidB(hier::Patch& patch,
+                                     const int temperature_id, const int fs_id);
 
    virtual void addDrivingForce(const double time, hier::Patch& patch,
                                 const int temperature_id, const int phase_id,
                                 const int eta_id, const int conc_id,
                                 const int f_l_id, const int f_a_id,
                                 const int f_b_id, const int rhs_id);
-
-   void computeDrivingForce(const double time, hier::Patch& patch,
-                            const int temperature_id, const int phase_id,
-                            const int eta_id, const int conc_id,
-                            const int f_l_id, const int f_a_id,
-                            const int f_b_id, const int rhs_id);
 
    virtual void computeSecondDerivativeEnergyPhaseL(
        const double temperature, const std::vector<double>& c,
@@ -206,31 +189,21 @@ class CALPHADFreeEnergyStrategyBinaryThreePhase : public ConcFreeEnergyStrategy
        std::shared_ptr<pdat::CellData<double> > cd_c_a,
        std::shared_ptr<pdat::CellData<double> > cd_c_b, const hier::Box& pbox);
 
-   void computeFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const int c_i_id,
-       const PhaseIndex pi, const bool gp);
+   void computeFreeEnergy(hier::Patch& patch, const int temperature_id,
+                          const int f_id, const int c_i_id, const PhaseIndex pi,
+                          const bool gp);
 
-   void computeDerivFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const int c_i_id,
-       const PhaseIndex pi);
+   void computeDerivFreeEnergy(hier::Patch& patch, const int temperature_id,
+                               const int f_id, const int c_i_id,
+                               const PhaseIndex pi);
 
-   void computeFreeEnergyPrivate(hier::Patch& patch, const int temperature_id,
-                                 const int f_id, const int c_i_id,
-                                 const PhaseIndex pi, const bool gp);
-
-   void computeDerivFreeEnergyPrivate(hier::Patch& patch,
-                                      const int temperature_id, const int f_id,
-                                      const int c_i_id, const PhaseIndex pi);
-
-   void computeFreeEnergyPrivatePatch(
+   void computeFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
        const bool gp);
 
-   void computeDerivFreeEnergyPrivatePatch(
+   void computeDerivFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi);

--- a/source/CALPHADFreeEnergyStrategyTernary.cc
+++ b/source/CALPHADFreeEnergyStrategyTernary.cc
@@ -114,83 +114,34 @@ void CALPHADFreeEnergyStrategyTernary::setup(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(fl_id >= 0);
-
-   assert(d_conc_l_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fl_id, d_conc_l_id,
-                            PhaseIndex::phaseL, gp);
-}
-
-//=======================================================================
-
 void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfl_id)
+    hier::Patch& patch, const int temperature_id, const int dfl_id)
 {
    assert(temperature_id >= 0);
    assert(dfl_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfl_id, d_conc_l_id,
-                                 PhaseIndex::phaseL);
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyTernary::computeFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(temperature_id >= 0.);
-   assert(fs_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fs_id, d_conc_a_id,
-                            PhaseIndex::phaseA, gp);
+   computeDerivFreeEnergy(patch, temperature_id, dfl_id, d_conc_l_id,
+                          PhaseIndex::phaseL);
 }
 
 //=======================================================================
 
 void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfs_id)
+    hier::Patch& patch, const int temperature_id, const int dfs_id)
 {
    assert(temperature_id >= 0.);
    assert(dfs_id >= 0);
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfs_id, d_conc_a_id,
-                                 PhaseIndex::phaseA);
-}
-
-//=======================================================================
-
-/*
- * Third phase not implemented for ternary alloys
- */
-void CALPHADFreeEnergyStrategyTernary::computeFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   (void)hierarchy;
-   (void)temperature_id;
-   (void)fs_id;
-   (void)gp;
-   TBOX_ERROR(
-       "CALPHADFreeEnergyStrategyTernary::computeFreeEnergySolidB() not "
-       "implemented!!!\n");
+   computeDerivFreeEnergy(patch, temperature_id, dfs_id, d_conc_a_id,
+                          PhaseIndex::phaseA);
 }
 
 //=======================================================================
 
 void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfs_id)
+    hier::Patch& patch, const int temperature_id, const int dfs_id)
 {
-   (void)hierarchy;
+   (void)patch;
    (void)temperature_id;
    (void)dfs_id;
    TBOX_ERROR(
@@ -209,8 +160,8 @@ void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyLiquid(
 
    assert(d_conc_l_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fl_id, d_conc_l_id,
-                            PhaseIndex::phaseL, gp);
+   computeFreeEnergy(patch, temperature_id, fl_id, d_conc_l_id,
+                     PhaseIndex::phaseL, gp);
 }
 
 //=======================================================================
@@ -222,8 +173,8 @@ void CALPHADFreeEnergyStrategyTernary::computeFreeEnergySolidA(
    assert(temperature_id >= 0.);
    assert(fs_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fs_id, d_conc_a_id,
-                            PhaseIndex::phaseA, gp);
+   computeFreeEnergy(patch, temperature_id, fs_id, d_conc_a_id,
+                     PhaseIndex::phaseA, gp);
 }
 
 //=======================================================================
@@ -240,7 +191,7 @@ void CALPHADFreeEnergyStrategyTernary::computeFreeEnergySolidB(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyPrivate(
+void CALPHADFreeEnergyStrategyTernary::computeFreeEnergy(
     hier::Patch& patch, const int temperature_id, const int f_id,
     const int conc_i_id, const PhaseIndex pi, const bool gp)
 {
@@ -262,12 +213,12 @@ void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeFreeEnergyPrivatePatch(pbox, temperature, f, c_i, pi, gp);
+   computeFreeEnergy(pbox, temperature, f, c_i, pi, gp);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergyPrivate(
+void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergy(
     hier::Patch& patch, const int temperature_id, const int df_id,
     const int conc_i_id, const PhaseIndex pi)
 {
@@ -289,60 +240,12 @@ void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeDerivFreeEnergyPrivatePatch(pbox, temperature, df, c_i, pi);
+   computeDerivFreeEnergy(pbox, temperature, df, c_i, pi);
 }
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int f_id, const int conc_i_id,
-    const PhaseIndex pi, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(f_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeFreeEnergyPrivate(*patch, temperature_id, f_id, conc_i_id, pi,
-                                  gp);
-      }
-   }
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int df_id, const int conc_i_id,
-    const PhaseIndex pi)
-{
-   assert(temperature_id >= 0);
-   assert(df_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, df_id, conc_i_id,
-                                       pi);
-      }
-   }
-}
-
-//=======================================================================
-
-void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyPrivatePatch(
+void CALPHADFreeEnergyStrategyTernary::computeFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
@@ -422,7 +325,7 @@ void CALPHADFreeEnergyStrategyTernary::computeFreeEnergyPrivatePatch(
 
 //=======================================================================
 
-void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergyPrivatePatch(
+void CALPHADFreeEnergyStrategyTernary::computeDerivFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_dfree_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi)

--- a/source/CALPHADFreeEnergyStrategyTernary.h
+++ b/source/CALPHADFreeEnergyStrategyTernary.h
@@ -8,30 +8,6 @@
 // This file is part of AMPE.
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// - Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the disclaimer below.
-// - Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the disclaimer (as noted below) in the
-//   documentation and/or other materials provided with the distribution.
-// - Neither the name of the LLNS/LLNL nor the names of its contributors may be
-//   used to endorse or promote products derived from this software without
-//   specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-// LLC, UT BATTELLE, LLC,
-// THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
 //
 #ifndef included_CALPHADFreeEnergyStrategyTernary
 #define included_CALPHADFreeEnergyStrategyTernary
@@ -72,29 +48,14 @@ class CALPHADFreeEnergyStrategyTernary : public ConcFreeEnergyStrategy
    virtual void setup(std::shared_ptr<tbox::Database> calphad_db,
                       std::shared_ptr<tbox::Database> newton_db);
 
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp);
+   void computeDerivFreeEnergyLiquid(hier::Patch& patch,
+                                     const int temperature_id, const int fl_id);
 
-   void computeDerivFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id);
+   void computeDerivFreeEnergySolidA(hier::Patch& patch,
+                                     const int temperature_id, const int fs_id);
 
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
-
-   void computeDerivFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
-
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
-
-   void computeDerivFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
+   void computeDerivFreeEnergySolidB(hier::Patch& patch,
+                                     const int temperature_id, const int fs_id);
 
    void computeFreeEnergyLiquid(hier::Patch& patch, const int temperature_id,
                                 const int fl_id, const bool gp);
@@ -240,31 +201,21 @@ class CALPHADFreeEnergyStrategyTernary : public ConcFreeEnergyStrategy
        std::shared_ptr<pdat::CellData<double> > cd_c_l,
        std::shared_ptr<pdat::CellData<double> > cd_c_a, const hier::Box& pbox);
 
-   void computeFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const int c_i_id,
-       const PhaseIndex pi, const bool gp);
+   void computeFreeEnergy(hier::Patch& patch, const int temperature_id,
+                          const int f_id, const int c_i_id, const PhaseIndex pi,
+                          const bool gp);
 
-   void computeDerivFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const int c_i_id,
-       const PhaseIndex pi);
+   void computeDerivFreeEnergy(hier::Patch& patch, const int temperature_id,
+                               const int f_id, const int c_i_id,
+                               const PhaseIndex pi);
 
-   void computeFreeEnergyPrivate(hier::Patch& patch, const int temperature_id,
-                                 const int f_id, const int c_i_id,
-                                 const PhaseIndex pi, const bool gp);
-
-   void computeDerivFreeEnergyPrivate(hier::Patch& patch,
-                                      const int temperature_id, const int f_id,
-                                      const int c_i_id, const PhaseIndex pi);
-
-   void computeFreeEnergyPrivatePatch(
+   void computeFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
        const bool gp);
 
-   void computeDerivFreeEnergyPrivatePatch(
+   void computeDerivFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi);

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES ${CMAKE_SOURCE_DIR}/source/main.cc
             ${CMAKE_SOURCE_DIR}/source/CALPHADFreeEnergyStrategyTernary.cc
             ${CMAKE_SOURCE_DIR}/source/tools.cc
             ${CMAKE_SOURCE_DIR}/source/FreeEnergyStrategy.cc
+            ${CMAKE_SOURCE_DIR}/source/ConcFreeEnergyStrategy.cc
             ${CMAKE_SOURCE_DIR}/source/AMPE.cc
             ${CMAKE_SOURCE_DIR}/source/Noise.cc
             ${CMAKE_SOURCE_DIR}/source/NormalNoise.cc

--- a/source/ConcFreeEnergyStrategy.cc
+++ b/source/ConcFreeEnergyStrategy.cc
@@ -9,13 +9,11 @@
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
 //
-#include "FreeEnergyStrategy.h"
+#include "ConcFreeEnergyStrategy.h"
 
-#include "SAMRAI/pdat/CellData.h"
-
-void FreeEnergyStrategy::computeFreeEnergyLiquid(
+void ConcFreeEnergyStrategy::computeDerivFreeEnergyLiquid(
     const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
+    const int temperature_id, const int fl_id)
 {
    const int maxln = hierarchy->getFinestLevelNumber();
    for (int ln = 0; ln <= maxln; ln++) {
@@ -25,14 +23,14 @@ void FreeEnergyStrategy::computeFreeEnergyLiquid(
            ++p) {
          std::shared_ptr<hier::Patch> patch = *p;
 
-         computeFreeEnergyLiquid(*patch, temperature_id, fl_id, gp);
+         computeDerivFreeEnergyLiquid(*patch, temperature_id, fl_id);
       }
    }
 }
 
-void FreeEnergyStrategy::computeFreeEnergySolidA(
+void ConcFreeEnergyStrategy::computeDerivFreeEnergySolidA(
     const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fa_id, const bool gp)
+    const int temperature_id, const int fl_id)
 {
    const int maxln = hierarchy->getFinestLevelNumber();
    for (int ln = 0; ln <= maxln; ln++) {
@@ -42,37 +40,15 @@ void FreeEnergyStrategy::computeFreeEnergySolidA(
            ++p) {
          std::shared_ptr<hier::Patch> patch = *p;
 
-         computeFreeEnergySolidA(*patch, temperature_id, fa_id, gp);
+         computeDerivFreeEnergySolidA(*patch, temperature_id, fl_id);
       }
    }
 }
 
-void FreeEnergyStrategy::computeDrivingForce(
-    const double time, const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int phase_id, const int eta_id,
-    const int conc_id, const int f_l_id, const int f_a_id, const int f_b_id,
-    const int rhs_id)
-{
-   const int maxln = hierarchy->getFinestLevelNumber();
-   for (int ln = 0; ln <= maxln; ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator p(level->begin()); p != level->end();
-           ++p) {
-         std::shared_ptr<hier::Patch> patch = *p;
-         computeDrivingForce(time, *patch, temperature_id, phase_id, eta_id,
-                             conc_id, f_l_id, f_a_id, f_b_id, rhs_id);
-      }
-   }
-}
-
-void FreeEnergyStrategy::computeFreeEnergySolidB(
+void ConcFreeEnergyStrategy::computeDerivFreeEnergySolidB(
     const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fb_id, const bool gp)
+    const int temperature_id, const int fl_id)
 {
-   assert(temperature_id >= 0);
-   assert(fb_id >= 0);
-
    const int maxln = hierarchy->getFinestLevelNumber();
    for (int ln = 0; ln <= maxln; ln++) {
       std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
@@ -81,7 +57,7 @@ void FreeEnergyStrategy::computeFreeEnergySolidB(
            ++p) {
          std::shared_ptr<hier::Patch> patch = *p;
 
-         computeFreeEnergySolidB(*patch, temperature_id, fb_id, gp);
+         computeDerivFreeEnergySolidB(*patch, temperature_id, fl_id);
       }
    }
 }

--- a/source/ConcFreeEnergyStrategy.h
+++ b/source/ConcFreeEnergyStrategy.h
@@ -1,3 +1,14 @@
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC and
+// UT-Battelle, LLC.
+// Produced at the Lawrence Livermore National Laboratory and
+// the Oak Ridge National Laboratory
+// Written by M.R. Dorr, J.-L. Fattebert and M.E. Wickett
+// LLNL-CODE-747500
+// All rights reserved.
+// This file is part of AMPE.
+// For details, see https://github.com/LLNL/AMPE
+// Please also read AMPE/LICENSE.
+//
 #ifndef included_ConcFreeEnergyStrategy
 #define included_ConcFreeEnergyStrategy
 
@@ -14,6 +25,30 @@ class ConcFreeEnergyStrategy : public FreeEnergyStrategy
                                 const double phi_well_scale,
                                 const std::string& phi_well_type,
                                 const int npts_phi, const int npts_c) = 0;
+
+   virtual void computeDerivFreeEnergyLiquid(
+       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
+       const int temperature_id, const int f_l_id);
+
+   virtual void computeDerivFreeEnergySolidA(
+       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
+       const int temperature_id, const int f_a_id);
+
+   virtual void computeDerivFreeEnergySolidB(
+       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
+       const int temperature_id, const int f_b_id);
+
+   virtual void computeDerivFreeEnergyLiquid(hier::Patch& patch,
+                                             const int temperature_id,
+                                             const int f_l_id) = 0;
+
+   virtual void computeDerivFreeEnergySolidA(hier::Patch& patch,
+                                             const int temperature_id,
+                                             const int f_a_id) = 0;
+
+   virtual void computeDerivFreeEnergySolidB(hier::Patch& patch,
+                                             const int temperature_id,
+                                             const int f_b_id) = 0;
 };
 
 #endif

--- a/source/DeltaTemperatureFreeEnergyStrategy.h
+++ b/source/DeltaTemperatureFreeEnergyStrategy.h
@@ -34,27 +34,6 @@ class DeltaTemperatureFreeEnergyStrategy : public FreeEnergyStrategy
 
    virtual ~DeltaTemperatureFreeEnergyStrategy(){};
 
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp)
-   {
-      (void)temperature_id;
-      (void)gp;
-
-      SAMRAI::math::HierarchyCellDataOpsReal<double> mathops(hierarchy);
-      mathops.setToScalar(fs_id, 0.);
-   };
-
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp)
-   {
-      (void)temperature_id;
-      (void)gp;
-      tbox::pout << "DeltaTemperatureFreeEnergyStrategy: undefined function!"
-                 << std::endl;
-   };
-
    virtual void addDrivingForce(const double time, hier::Patch& patch,
                                 const int temperature_id, const int phase_id,
                                 const int eta_id, const int conc_id,

--- a/source/FreeEnergyStrategy.h
+++ b/source/FreeEnergyStrategy.h
@@ -38,25 +38,9 @@ class FreeEnergyStrategy
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,
        const int temperature_id, const int f_l_id, const bool gp);
 
-   virtual void computeDerivFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_l_id)
-   {
-      (void)temperature_id;  // unused
-      computeDerivFreeEnergy(hierarchy, f_l_id);
-   }
-
    virtual void computeFreeEnergySolidA(
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,
        const int temperature_id, const int f_a_id, const bool gp);
-
-   virtual void computeDerivFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_a_id)
-   {
-      (void)temperature_id;  // unused
-      computeDerivFreeEnergy(hierarchy, f_a_id);
-   }
 
    virtual void computeFreeEnergySolidB(
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,

--- a/source/HBSMFreeEnergyStrategy.cc
+++ b/source/HBSMFreeEnergyStrategy.cc
@@ -8,30 +8,6 @@
 // This file is part of AMPE.
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// - Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the disclaimer below.
-// - Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the disclaimer (as noted below) in the
-//   documentation and/or other materials provided with the distribution.
-// - Neither the name of the LLNS/LLNL nor the names of its contributors may be
-//   used to endorse or promote products derived from this software without
-//   specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-// LLC, UT BATTELLE, LLC,
-// THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
 //
 #include "SAMRAI/tbox/InputManager.h"
 
@@ -131,155 +107,6 @@ HBSMFreeEnergyStrategy::HBSMFreeEnergyStrategy(
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::computeFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
-{
-   assert(fl_id >= 0);
-   assert(temperature_id >= 0);
-   assert(d_conc_l_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeFreeEnergyPrivate(*patch, temperature_id, d_A_liquid,
-                                  d_Ceq_liquid, fl_id, d_conc_l_id,
-                                  d_energy_conv_factor_L);
-      }
-   }
-}
-
-//=======================================================================
-
-void HBSMFreeEnergyStrategy::computeDerivFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id)
-{
-   assert(fl_id >= 0);
-   assert(temperature_id >= 0);
-
-   assert(d_conc_l_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, d_A_liquid,
-                                       d_Ceq_liquid, fl_id, d_conc_l_id,
-                                       d_energy_conv_factor_L);
-      }
-   }
-}
-
-//=======================================================================
-
-void HBSMFreeEnergyStrategy::computeFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(fs_id >= 0);
-   assert(temperature_id >= 0.);
-
-   assert(d_conc_a_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeFreeEnergyPrivate(*patch, temperature_id, d_A_solid_A,
-                                  d_Ceq_solid_A, fs_id, d_conc_a_id,
-                                  d_energy_conv_factor_A);
-      }
-   }
-}
-
-//=======================================================================
-
-void HBSMFreeEnergyStrategy::computeDerivFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfs_id)
-{
-   assert(dfs_id >= 0);
-   assert(temperature_id >= 0.);
-
-   assert(d_conc_a_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, d_A_solid_A,
-                                       d_Ceq_solid_A, dfs_id, d_conc_a_id,
-                                       d_energy_conv_factor_A);
-      }
-   }
-}
-
-//=======================================================================
-
-void HBSMFreeEnergyStrategy::computeFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(fs_id >= 0);
-   assert(temperature_id >= 0.);
-
-   assert(d_conc_a_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeFreeEnergyPrivate(*patch, temperature_id, d_A_solid_B,
-                                  d_Ceq_solid_B, fs_id, d_conc_a_id,
-                                  d_energy_conv_factor_B);
-      }
-   }
-}
-
-//=======================================================================
-
-void HBSMFreeEnergyStrategy::computeDerivFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int dfs_id)
-{
-   assert(dfs_id >= 0);
-   assert(temperature_id >= 0.);
-
-   assert(d_conc_a_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, d_A_solid_B,
-                                       d_Ceq_solid_B, dfs_id, d_conc_a_id,
-                                       d_energy_conv_factor_B);
-      }
-   }
-}
-
-//=======================================================================
-
 void HBSMFreeEnergyStrategy::computeFreeEnergyLiquid(hier::Patch& patch,
                                                      const int temperature_id,
                                                      const int fl_id,
@@ -290,8 +117,8 @@ void HBSMFreeEnergyStrategy::computeFreeEnergyLiquid(hier::Patch& patch,
 
    assert(d_conc_l_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, d_A_liquid, d_Ceq_liquid,
-                            fl_id, d_conc_l_id, d_energy_conv_factor_L);
+   computeFreeEnergy(patch, temperature_id, d_A_liquid, d_Ceq_liquid, fl_id,
+                     d_conc_l_id, d_energy_conv_factor_L);
 }
 
 //=======================================================================
@@ -306,8 +133,8 @@ void HBSMFreeEnergyStrategy::computeFreeEnergySolidA(hier::Patch& patch,
 
    assert(d_conc_a_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, d_A_solid_A, d_Ceq_solid_A,
-                            fs_id, d_conc_a_id, d_energy_conv_factor_A);
+   computeFreeEnergy(patch, temperature_id, d_A_solid_A, d_Ceq_solid_A, fs_id,
+                     d_conc_a_id, d_energy_conv_factor_A);
 }
 
 //=======================================================================
@@ -322,50 +149,15 @@ void HBSMFreeEnergyStrategy::computeFreeEnergySolidB(hier::Patch& patch,
 
    assert(d_conc_b_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, d_A_solid_B, d_Ceq_solid_B,
-                            fs_id, d_conc_b_id, d_energy_conv_factor_B);
+   computeFreeEnergy(patch, temperature_id, d_A_solid_B, d_Ceq_solid_B, fs_id,
+                     d_conc_b_id, d_energy_conv_factor_B);
 }
 
 //=======================================================================
 
-// double HBSMFreeEnergyStrategy::computeValFreeEnergyLiquid(
-//   const double temperature,
-//   const double conc,
-//   const bool gp )
-//{
-//   return computeFreeEnergyPrivate(
-//      temperature, conc,
-//      d_A_liquid, d_Ceq_liquid,
-//      d_energy_conv_factor_L, gp );
-//}
-//
-// double HBSMFreeEnergyStrategy::computeValFreeEnergySolidA(
-//   const double temperature,
-//   const double conc,
-//   const bool gp )
-//{
-//   return computeFreeEnergyPrivate(
-//      temperature, conc,
-//      d_A_solid_A, d_Ceq_solid_A,
-//      d_energy_conv_factor_A, gp );
-//}
-//
-// double HBSMFreeEnergyStrategy::computeValFreeEnergySolidB(
-//   const double temperature,
-//   const double conc,
-//   const bool gp )
-//{
-//   return computeFreeEnergyPrivate(
-//      temperature, conc,
-//      d_A_solid_B, d_Ceq_solid_B,
-//      d_energy_conv_factor_B, gp );
-//}
-//
-//-----------------------------------------------------------------------
-
 // \/\/ No temperature dependence yet
 
-double HBSMFreeEnergyStrategy::computeFreeEnergyPrivate(
+double HBSMFreeEnergyStrategy::computeFreeEnergy(
     const double temperature, const double conc, const double A,
     const double Ceq, const double energy_factor, const bool gp) const
 {
@@ -378,8 +170,7 @@ double HBSMFreeEnergyStrategy::computeFreeEnergyPrivate(
 
    // subtract -mu*c to get grand potential
    if (gp)
-      fe -= computeDerivFreeEnergyPrivate(temperature, conc, A, Ceq,
-                                          energy_factor) *
+      fe -= computeDerivFreeEnergy(temperature, conc, A, Ceq, energy_factor) *
             conc;
 
    return fe;
@@ -387,7 +178,7 @@ double HBSMFreeEnergyStrategy::computeFreeEnergyPrivate(
 
 //=======================================================================
 
-double HBSMFreeEnergyStrategy::computeDerivFreeEnergyPrivate(
+double HBSMFreeEnergyStrategy::computeDerivFreeEnergy(
     const double temperature, const double conc, const double A,
     const double Ceq, const double energy_factor) const
 {
@@ -400,48 +191,12 @@ double HBSMFreeEnergyStrategy::computeDerivFreeEnergyPrivate(
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::computeFreeEnergyPrivate(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const double A, const double Ceq, const int f_id,
-    const int conc_i_id, const double energy_factor)
-{
-   assert(temperature_id >= 0);
-   assert(f_id >= 0);
-   assert(conc_i_id >= 0);
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         const hier::Box& pbox = patch->getBox();
-
-         std::shared_ptr<pdat::CellData<double> > temperature(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(temperature_id)));
-
-         std::shared_ptr<pdat::CellData<double> > f(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(f_id)));
-
-         std::shared_ptr<pdat::CellData<double> > c_i(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(conc_i_id)));
-
-         computeFreeEnergyPrivatePatch(pbox, temperature, A, Ceq, f, c_i,
-                                       energy_factor);
-      }
-   }
-}
-
-//=======================================================================
-
-void HBSMFreeEnergyStrategy::computeFreeEnergyPrivate(
-    hier::Patch& patch, const int temperature_id, const double A,
-    const double Ceq, const int f_id, const int conc_i_id,
-    const double energy_factor)
+void HBSMFreeEnergyStrategy::computeFreeEnergy(hier::Patch& patch,
+                                               const int temperature_id,
+                                               const double A, const double Ceq,
+                                               const int f_id,
+                                               const int conc_i_id,
+                                               const double energy_factor)
 {
    assert(temperature_id >= 0);
    assert(f_id >= 0);
@@ -461,13 +216,12 @@ void HBSMFreeEnergyStrategy::computeFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeFreeEnergyPrivatePatch(pbox, temperature, A, Ceq, f, c_i,
-                                 energy_factor);
+   computeFreeEnergy(pbox, temperature, A, Ceq, f, c_i, energy_factor);
 }
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::computeDerivFreeEnergyPrivate(
+void HBSMFreeEnergyStrategy::computeDerivFreeEnergy(
     hier::Patch& patch, const int temperature_id, const double A,
     const double Ceq, const int df_id, const int conc_i_id,
     const double energy_factor)
@@ -490,13 +244,12 @@ void HBSMFreeEnergyStrategy::computeDerivFreeEnergyPrivate(
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeDerivFreeEnergyPrivatePatch(pbox, temperature, A, Ceq, df, c_i,
-                                      energy_factor);
+   computeDerivFreeEnergy(pbox, temperature, A, Ceq, df, c_i, energy_factor);
 }
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::computeFreeEnergyPrivatePatch(
+void HBSMFreeEnergyStrategy::computeFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     const double A, const double Ceq,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
@@ -568,8 +321,7 @@ void HBSMFreeEnergyStrategy::computeFreeEnergyPrivatePatch(
 
             double c_i = ptr_c_i[idx_c_i];
 
-            ptr_f[idx_f] =
-                computeFreeEnergyPrivate(t, c_i, A, Ceq, energy_factor);
+            ptr_f[idx_f] = computeFreeEnergy(t, c_i, A, Ceq, energy_factor);
          }
       }
    }
@@ -577,7 +329,7 @@ void HBSMFreeEnergyStrategy::computeFreeEnergyPrivatePatch(
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::computeDerivFreeEnergyPrivatePatch(
+void HBSMFreeEnergyStrategy::computeDerivFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     const double A, const double Ceq,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
@@ -650,7 +402,7 @@ void HBSMFreeEnergyStrategy::computeDerivFreeEnergyPrivatePatch(
             double c_i = ptr_c_i[idx_c_i];
 
             ptr_f[idx_f] =
-                computeDerivFreeEnergyPrivate(t, c_i, A, Ceq, energy_factor);
+                computeDerivFreeEnergy(t, c_i, A, Ceq, energy_factor);
          }
       }
    }
@@ -732,13 +484,12 @@ void HBSMFreeEnergyStrategy::addDrivingForce(
 
    const hier::Box& pbox = patch.getBox();
 
-   addDrivingForceOnPatchPrivate(rhs, t, phase, eta, fl, fa, fb, c_l, c_a, c_b,
-                                 pbox);
+   addDrivingForceOnPatch(rhs, t, phase, eta, fl, fa, fb, c_l, c_a, c_b, pbox);
 }
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::addDrivingForceOnPatchPrivate(
+void HBSMFreeEnergyStrategy::addDrivingForceOnPatch(
     std::shared_ptr<pdat::CellData<double> > cd_rhs,
     std::shared_ptr<pdat::CellData<double> > cd_temperature,
     std::shared_ptr<pdat::CellData<double> > cd_phi,
@@ -896,8 +647,7 @@ double HBSMFreeEnergyStrategy::computeMu(const double t, const double c_l)
    const double A = d_A_liquid;
    const double Ceq = d_Ceq_liquid;
 
-   double mu =
-       computeDerivFreeEnergyPrivate(t, c_l, A, Ceq, d_energy_conv_factor_L);
+   double mu = computeDerivFreeEnergy(t, c_l, A, Ceq, d_energy_conv_factor_L);
 
    return mu;
 }
@@ -977,13 +727,13 @@ void HBSMFreeEnergyStrategy::addDrivingForceEta(
 
    const hier::Box& pbox = patch.getBox();
 
-   addDrivingForceEtaOnPatchPrivate(rhs, t, phase, eta, f_l, f_a, f_b, c_l, c_a,
-                                    c_b, pbox);
+   addDrivingForceEtaOnPatch(rhs, t, phase, eta, f_l, f_a, f_b, c_l, c_a, c_b,
+                             pbox);
 }
 
 //=======================================================================
 
-void HBSMFreeEnergyStrategy::addDrivingForceEtaOnPatchPrivate(
+void HBSMFreeEnergyStrategy::addDrivingForceEtaOnPatch(
     std::shared_ptr<pdat::CellData<double> > cd_rhs,
     std::shared_ptr<pdat::CellData<double> > cd_temperature,
     std::shared_ptr<pdat::CellData<double> > cd_phi,

--- a/source/HBSMFreeEnergyStrategy.h
+++ b/source/HBSMFreeEnergyStrategy.h
@@ -8,30 +8,6 @@
 // This file is part of AMPE.
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// - Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the disclaimer below.
-// - Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the disclaimer (as noted below) in the
-//   documentation and/or other materials provided with the distribution.
-// - Neither the name of the LLNS/LLNL nor the names of its contributors may be
-//   used to endorse or promote products derived from this software without
-//   specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-// LLC, UT BATTELLE, LLC,
-// THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
 //
 #ifndef included_HBSMFreeEnergyStrategy
 #define included_HBSMFreeEnergyStrategy
@@ -54,42 +30,6 @@ class HBSMFreeEnergyStrategy : public FreeEnergyStrategy
                           const int conc_b_id, const bool with_third_phase);
 
    ~HBSMFreeEnergyStrategy(){};
-
-   //   double computeValFreeEnergyLiquid(
-   //      const double temperature, const double conc,
-   //      const bool gp = false );
-
-   //   double computeValFreeEnergySolidA(
-   //      const double temperature, const double conc,
-   //      const bool gp = false );
-
-   //   double computeValFreeEnergySolidB(
-   //      const double temperature, const double conc,
-   //      const bool gp = false );
-
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp = false);
-
-   void computeDerivFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id);
-
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp = false);
-
-   void computeDerivFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
-
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp = false);
-
-   void computeDerivFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id);
 
    void computeFreeEnergyLiquid(hier::Patch& patch, const int temperature_id,
                                 const int fl_id, const bool gp = false);
@@ -133,26 +73,18 @@ class HBSMFreeEnergyStrategy : public FreeEnergyStrategy
    void preRunDiagnostics(const double temperature){};
 
  private:
-   double computeFreeEnergyPrivate(const double temperature, const double conc,
-                                   const double A, const double Ceq,
-                                   const double energy_factor,
-                                   const bool gp = false) const;
+   double computeFreeEnergy(const double temperature, const double conc,
+                            const double A, const double Ceq,
+                            const double energy_factor,
+                            const bool gp = false) const;
 
-   void computeFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const double A, const double Ceq,
-       const int f_id, const int c_i_id, const double energy_factor);
+   void computeFreeEnergy(hier::Patch& patch, const int temperature_id,
+                          const double A, const double Ceq, const int f_id,
+                          const int c_i_id, const double energy_factor);
 
-   void computeFreeEnergyPrivate(hier::Patch& patch, const int temperature_id,
-                                 const double A, const double Ceq,
-                                 const int f_id, const int c_i_id,
-                                 const double energy_factor);
-
-   void computeDerivFreeEnergyPrivate(hier::Patch& patch,
-                                      const int temperature_id, const double A,
-                                      const double Ceq, const int f_id,
-                                      const int c_i_id,
-                                      const double energy_factor);
+   void computeDerivFreeEnergy(hier::Patch& patch, const int temperature_id,
+                               const double A, const double Ceq, const int f_id,
+                               const int c_i_id, const double energy_factor);
 
    double computeLiquidConcentration(const double hphi, const double heta,
                                      const double c, const double Al,
@@ -172,21 +104,21 @@ class HBSMFreeEnergyStrategy : public FreeEnergyStrategy
                                      const double Ceql, const double CeqA,
                                      const double CeqB) const;
 
-   void computeFreeEnergyPrivatePatch(
+   void computeFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        const double A, const double Ceq,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i,
        const double energy_factor);
 
-   void computeDerivFreeEnergyPrivatePatch(
+   void computeDerivFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        const double A, const double Ceq,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i,
        const double energy_factor);
 
-   void addDrivingForceOnPatchPrivate(
+   void addDrivingForceOnPatch(
        std::shared_ptr<pdat::CellData<double> > cd_rhs,
        std::shared_ptr<pdat::CellData<double> > cd_temperature,
        std::shared_ptr<pdat::CellData<double> > cd_phi,
@@ -198,7 +130,7 @@ class HBSMFreeEnergyStrategy : public FreeEnergyStrategy
        std::shared_ptr<pdat::CellData<double> > cd_c_a,
        std::shared_ptr<pdat::CellData<double> > cd_c_b, const hier::Box& pbox);
 
-   void addDrivingForceEtaOnPatchPrivate(
+   void addDrivingForceEtaOnPatch(
        std::shared_ptr<pdat::CellData<double> > cd_rhs,
        std::shared_ptr<pdat::CellData<double> > cd_temperature,
        std::shared_ptr<pdat::CellData<double> > cd_phi,
@@ -212,10 +144,9 @@ class HBSMFreeEnergyStrategy : public FreeEnergyStrategy
 
    double computeMu(const double t, const double c);
 
-   double computeDerivFreeEnergyPrivate(const double temperature,
-                                        const double conc, const double A,
-                                        const double Ceq,
-                                        const double energy_factor) const;
+   double computeDerivFreeEnergy(const double temperature, const double conc,
+                                 const double A, const double Ceq,
+                                 const double energy_factor) const;
 
    EnergyInterpolationType d_energy_interp_func_type;
 

--- a/source/KKSdiluteBinary.cc
+++ b/source/KKSdiluteBinary.cc
@@ -8,30 +8,6 @@
 // This file is part of AMPE.
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// - Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the disclaimer below.
-// - Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the disclaimer (as noted below) in the
-//   documentation and/or other materials provided with the distribution.
-// - Neither the name of the LLNS/LLNL nor the names of its contributors may be
-//   used to endorse or promote products derived from this software without
-//   specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-// LLC, UT BATTELLE, LLC,
-// THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
 //
 #include "ConcFort.h"
 #include "QuatParams.h"
@@ -101,19 +77,6 @@ void KKSdiluteBinary::setup(std::shared_ptr<tbox::Database> conc_db)
 
 //=======================================================================
 
-void KKSdiluteBinary::computeFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
-{
-   assert(temperature_id >= 0);
-   assert(fl_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fl_id,
-                            PhaseIndex::phaseL, gp);
-}
-
-//=======================================================================
-
 void KKSdiluteBinary::computeDerivFreeEnergyLiquid(
     const std::shared_ptr<hier::PatchHierarchy> hierarchy,
     const int temperature_id, const int dfl_id)
@@ -123,21 +86,8 @@ void KKSdiluteBinary::computeDerivFreeEnergyLiquid(
 
    // tbox::pout<<"d_conc_l_id="<<d_conc_l_id<<std::endl;
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfl_id,
-                                 PhaseIndex::phaseL);
-}
-
-//=======================================================================
-
-void KKSdiluteBinary::computeFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(temperature_id >= 0.);
-   assert(fs_id >= 0);
-
-   computeFreeEnergyPrivate(hierarchy, temperature_id, fs_id,
-                            PhaseIndex::phaseA, gp);
+   computeDerivFreeEnergy(hierarchy, temperature_id, dfl_id,
+                          PhaseIndex::phaseL);
 }
 
 //=======================================================================
@@ -152,20 +102,8 @@ void KKSdiluteBinary::computeDerivFreeEnergySolidA(
 
    // tbox::pout<<"d_conc_a_id="<<d_conc_a_id<<std::endl;
 
-   computeDerivFreeEnergyPrivate(hierarchy, temperature_id, dfs_id,
-                                 PhaseIndex::phaseA);
-}
-
-//=======================================================================
-
-void KKSdiluteBinary::computeFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   (void)hierarchy;
-   (void)temperature_id;
-   (void)fs_id;
-   (void)gp;
+   computeDerivFreeEnergy(hierarchy, temperature_id, dfs_id,
+                          PhaseIndex::phaseA);
 }
 
 //=======================================================================
@@ -189,8 +127,7 @@ void KKSdiluteBinary::computeFreeEnergyLiquid(hier::Patch& patch,
    assert(temperature_id >= 0);
    assert(fl_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fl_id, PhaseIndex::phaseL,
-                            gp);
+   computeFreeEnergy(patch, temperature_id, fl_id, PhaseIndex::phaseL, gp);
 }
 
 //=======================================================================
@@ -202,8 +139,7 @@ void KKSdiluteBinary::computeFreeEnergySolidA(hier::Patch& patch,
    assert(temperature_id >= 0.);
    assert(fs_id >= 0);
 
-   computeFreeEnergyPrivate(patch, temperature_id, fs_id, PhaseIndex::phaseA,
-                            gp);
+   computeFreeEnergy(patch, temperature_id, fs_id, PhaseIndex::phaseA, gp);
 }
 
 //=======================================================================
@@ -220,11 +156,10 @@ void KKSdiluteBinary::computeFreeEnergySolidB(hier::Patch& patch,
 
 //=======================================================================
 
-void KKSdiluteBinary::computeFreeEnergyPrivate(hier::Patch& patch,
-                                               const int temperature_id,
-                                               const int f_id,
-                                               const PhaseIndex pi,
-                                               const bool gp)
+void KKSdiluteBinary::computeFreeEnergy(hier::Patch& patch,
+                                        const int temperature_id,
+                                        const int f_id, const PhaseIndex pi,
+                                        const bool gp)
 {
    assert(temperature_id >= 0);
    assert(f_id >= 0);
@@ -250,15 +185,15 @@ void KKSdiluteBinary::computeFreeEnergyPrivate(hier::Patch& patch,
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeFreeEnergyPrivatePatch(pbox, temperature, f, c_i, pi, gp);
+   computeFreeEnergy(pbox, temperature, f, c_i, pi, gp);
 }
 
 //=======================================================================
 
-void KKSdiluteBinary::computeDerivFreeEnergyPrivate(hier::Patch& patch,
-                                                    const int temperature_id,
-                                                    const int df_id,
-                                                    const PhaseIndex pi)
+void KKSdiluteBinary::computeDerivFreeEnergy(hier::Patch& patch,
+                                             const int temperature_id,
+                                             const int df_id,
+                                             const PhaseIndex pi)
 {
    assert(temperature_id >= 0);
    assert(df_id >= 0);
@@ -284,12 +219,12 @@ void KKSdiluteBinary::computeDerivFreeEnergyPrivate(hier::Patch& patch,
        SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
            patch.getPatchData(conc_i_id)));
 
-   computeDerivFreeEnergyPrivatePatch(pbox, temperature, df, c_i, pi);
+   computeDerivFreeEnergy(pbox, temperature, df, c_i, pi);
 }
 
 //=======================================================================
 
-void KKSdiluteBinary::computeFreeEnergyPrivate(
+void KKSdiluteBinary::computeFreeEnergy(
     const std::shared_ptr<hier::PatchHierarchy> hierarchy,
     const int temperature_id, const int f_id, const PhaseIndex pi,
     const bool gp)
@@ -304,14 +239,14 @@ void KKSdiluteBinary::computeFreeEnergyPrivate(
            ip++) {
          std::shared_ptr<hier::Patch> patch = *ip;
 
-         computeFreeEnergyPrivate(*patch, temperature_id, f_id, pi, gp);
+         computeFreeEnergy(*patch, temperature_id, f_id, pi, gp);
       }
    }
 }
 
 //=======================================================================
 
-void KKSdiluteBinary::computeDerivFreeEnergyPrivate(
+void KKSdiluteBinary::computeDerivFreeEnergy(
     const std::shared_ptr<hier::PatchHierarchy> hierarchy,
     const int temperature_id, const int df_id, const PhaseIndex pi)
 {
@@ -325,14 +260,14 @@ void KKSdiluteBinary::computeDerivFreeEnergyPrivate(
            ip++) {
          std::shared_ptr<hier::Patch> patch = *ip;
 
-         computeDerivFreeEnergyPrivate(*patch, temperature_id, df_id, pi);
+         computeDerivFreeEnergy(*patch, temperature_id, df_id, pi);
       }
    }
 }
 
 //=======================================================================
 
-void KKSdiluteBinary::computeFreeEnergyPrivatePatch(
+void KKSdiluteBinary::computeFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
@@ -412,7 +347,7 @@ void KKSdiluteBinary::computeFreeEnergyPrivatePatch(
 
 //=======================================================================
 
-void KKSdiluteBinary::computeDerivFreeEnergyPrivatePatch(
+void KKSdiluteBinary::computeDerivFreeEnergy(
     const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
     std::shared_ptr<pdat::CellData<double> > cd_free_energy,
     std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi)

--- a/source/KKSdiluteBinary.h
+++ b/source/KKSdiluteBinary.h
@@ -8,30 +8,6 @@
 // This file is part of AMPE.
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// - Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the disclaimer below.
-// - Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the disclaimer (as noted below) in the
-//   documentation and/or other materials provided with the distribution.
-// - Neither the name of the LLNS/LLNL nor the names of its contributors may be
-//   used to endorse or promote products derived from this software without
-//   specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-// LLC, UT BATTELLE, LLC,
-// THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
 //
 #ifndef included_KKSdiluteBinary
 #define included_KKSdiluteBinary
@@ -64,25 +40,13 @@ class KKSdiluteBinary : public FreeEnergyStrategy
 
    virtual void setup(std::shared_ptr<tbox::Database> calphad_db);
 
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp);
-
    void computeDerivFreeEnergyLiquid(
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,
        const int temperature_id, const int fl_id);
 
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
-
    void computeDerivFreeEnergySolidA(
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,
        const int temperature_id, const int fs_id);
-
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp);
 
    void computeDerivFreeEnergySolidB(
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,
@@ -202,35 +166,32 @@ class KKSdiluteBinary : public FreeEnergyStrategy
        std::shared_ptr<pdat::CellData<double> > cd_c_l,
        std::shared_ptr<pdat::CellData<double> > cd_c_a, const hier::Box& pbox);
 
-   void computeFreeEnergyPrivate(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int f_id, const PhaseIndex pi,
-       const bool gp);
+   void computeFreeEnergy(const std::shared_ptr<hier::PatchHierarchy> hierarchy,
+                          const int temperature_id, const int f_id,
+                          const PhaseIndex pi, const bool gp);
 
-   void computeDerivFreeEnergyPrivate(
+   void computeDerivFreeEnergy(
        const std::shared_ptr<hier::PatchHierarchy> hierarchy,
        const int temperature_id, const int f_id, const PhaseIndex pi);
 
-   void computeFreeEnergyPrivate(hier::Patch& patch, const int temperature_id,
-                                 const int f_id, const PhaseIndex pi,
-                                 const bool gp);
+   void computeFreeEnergy(hier::Patch& patch, const int temperature_id,
+                          const int f_id, const PhaseIndex pi, const bool gp);
 
-   void computeDerivFreeEnergyPrivate(hier::Patch& patch,
-                                      const int temperature_id, const int f_id,
-                                      const PhaseIndex pi);
+   void computeDerivFreeEnergy(hier::Patch& patch, const int temperature_id,
+                               const int f_id, const PhaseIndex pi);
 
-   void computeFreeEnergyPrivatePatch(
+   void computeFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi,
        const bool gp);
 
-   void computeDerivFreeEnergyPrivatePatch(
+   void computeDerivFreeEnergy(
        const hier::Box& pbox, std::shared_ptr<pdat::CellData<double> > cd_temp,
        std::shared_ptr<pdat::CellData<double> > cd_free_energy,
        std::shared_ptr<pdat::CellData<double> > cd_conc_i, const PhaseIndex pi);
 
-   void addDrivingForceEtaOnPatchPrivate(
+   void addDrivingForceEtaOnPatch(
        std::shared_ptr<pdat::CellData<double> > cd_rhs,
        std::shared_ptr<pdat::CellData<double> > cd_temperature,
        std::shared_ptr<pdat::CellData<double> > cd_phi,

--- a/source/TemperatureFreeEnergyStrategy.cc
+++ b/source/TemperatureFreeEnergyStrategy.cc
@@ -88,43 +88,6 @@ double TemperatureFreeEnergyStrategy::computeValFreeEnergyLiquid(
 //=======================================================================
 
 void TemperatureFreeEnergyStrategy::computeFreeEnergyLiquid(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fl_id, const bool gp)
-{
-   assert(fl_id >= 0);
-   (void)temperature_id;  // unused
-   (void)gp;
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-         const hier::Box& pbox = patch->getBox();
-
-         std::shared_ptr<pdat::CellData<double> > fl(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(fl_id)));
-         assert(fl);
-         std::shared_ptr<pdat::CellData<double> > temperature(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(temperature_id)));
-         assert(temperature);
-
-         pdat::CellIterator iend(pdat::CellGeometry::end(pbox));
-         for (pdat::CellIterator i(pdat::CellGeometry::begin(pbox)); i != iend;
-              ++i) {
-            pdat::CellIndex cell = *i;
-            (*fl)(cell) = computeValFreeEnergyLiquid((*temperature)(cell), 0.);
-         }
-      }
-   }
-}
-
-//=======================================================================
-
-void TemperatureFreeEnergyStrategy::computeFreeEnergyLiquid(
     hier::Patch& patch, const int temperature_id, const int fl_id,
     const bool gp)
 {
@@ -153,33 +116,6 @@ void TemperatureFreeEnergyStrategy::computeFreeEnergyLiquid(
 //=======================================================================
 
 void TemperatureFreeEnergyStrategy::computeFreeEnergySolidA(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(fs_id >= 0);
-   (void)temperature_id;  // unused
-   (void)gp;
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ip++) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         std::shared_ptr<pdat::CellData<double> > fs(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(fs_id)));
-         assert(fs);
-
-         fs->fillAll(d_f_a);
-      }
-   }
-}
-
-//=======================================================================
-
-void TemperatureFreeEnergyStrategy::computeFreeEnergySolidA(
     hier::Patch& patch, const int temperature_id, const int fs_id,
     const bool gp)
 {
@@ -193,33 +129,6 @@ void TemperatureFreeEnergyStrategy::computeFreeEnergySolidA(
    assert(fs);
 
    fs->fillAll(d_f_a);
-}
-
-//=======================================================================
-
-void TemperatureFreeEnergyStrategy::computeFreeEnergySolidB(
-    const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-    const int temperature_id, const int fs_id, const bool gp)
-{
-   assert(fs_id >= 0);
-   (void)temperature_id;  // unused
-   (void)gp;
-
-   for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ln++) {
-      std::shared_ptr<hier::PatchLevel> level = hierarchy->getPatchLevel(ln);
-
-      for (hier::PatchLevel::Iterator ip(level->begin()); ip != level->end();
-           ++ip) {
-         std::shared_ptr<hier::Patch> patch = *ip;
-
-         std::shared_ptr<pdat::CellData<double> > fs(
-             SAMRAI_SHARED_PTR_CAST<pdat::CellData<double>, hier::PatchData>(
-                 patch->getPatchData(fs_id)));
-         assert(fs);
-
-         fs->fillAll(d_f_b);
-      }
-   }
 }
 
 //=======================================================================

--- a/source/TemperatureFreeEnergyStrategy.h
+++ b/source/TemperatureFreeEnergyStrategy.h
@@ -8,30 +8,6 @@
 // This file is part of AMPE.
 // For details, see https://github.com/LLNL/AMPE
 // Please also read AMPE/LICENSE.
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-// - Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the disclaimer below.
-// - Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the disclaimer (as noted below) in the
-//   documentation and/or other materials provided with the distribution.
-// - Neither the name of the LLNS/LLNL nor the names of its contributors may be
-//   used to endorse or promote products derived from this software without
-//   specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-// LLC, UT BATTELLE, LLC,
-// THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
 //
 #ifndef included_TemperatureFreeEnergyStrategy
 #define included_TemperatureFreeEnergyStrategy
@@ -59,18 +35,6 @@ class TemperatureFreeEnergyStrategy : public FreeEnergyStrategy
        const bool with_third_phase);
 
    ~TemperatureFreeEnergyStrategy(){};
-
-   void computeFreeEnergyLiquid(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fl_id, const bool gp = false);
-
-   void computeFreeEnergySolidA(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp = false);
-
-   void computeFreeEnergySolidB(
-       const std::shared_ptr<hier::PatchHierarchy> hierarchy,
-       const int temperature_id, const int fs_id, const bool gp = false);
 
    void computeFreeEnergyLiquid(hier::Patch& patch, const int temperature_id,
                                 const int fl_id, const bool gp = false);


### PR DESCRIPTION
General strategy is to implement loop over levels in base classes,
FreeEnergy and ConcFreeEnergy, and have derived classes implement
computation on patch